### PR TITLE
Fix: SignUpIn SecurityConfig

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -8,7 +8,7 @@
         <processorPath useClasspath="false">
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.30/f195ee86e6c896ea47a1d39defbe20eb59cd149d/lombok-1.18.30.jar" />
         </processorPath>
-        <module name="wdam.wdam.main" />
+        <module name="com.back.wdam.main" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="17" />

--- a/wdam/.gitignore
+++ b/wdam/.gitignore
@@ -22,6 +22,7 @@ bin/
 !**/src/test/**/bin/
 
 ### IntelliJ IDEA ###
+application.properties
 .idea
 *.iws
 *.iml

--- a/wdam/src/main/java/com/back/wdam/user/config/SecurityConfig.java
+++ b/wdam/src/main/java/com/back/wdam/user/config/SecurityConfig.java
@@ -58,11 +58,18 @@ public class SecurityConfig {
                 .sessionManagement(httpSecuritySessionManagementConfigurer -> httpSecuritySessionManagementConfigurer
                                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)) //세션 사용 X
                 .authorizeHttpRequests((authorizeRequests) -> authorizeRequests
-                        // 인증(토큰) 없이 접속 가능한 api
+                        //인증 불필요
                         .requestMatchers(new AntPathRequestMatcher("/users/signup")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/users/login")).permitAll()
-                        .requestMatchers(new AntPathRequestMatcher("/")).permitAll()
-                        .anyRequest().authenticated()  // 나머지는 인증 필요
+                        //인증 필요
+                        .requestMatchers(new AntPathRequestMatcher("/users/update")).authenticated()
+                        .requestMatchers(new AntPathRequestMatcher("/users/logout")).authenticated()
+                        .requestMatchers(new AntPathRequestMatcher("/users")).authenticated()
+                        .requestMatchers(new AntPathRequestMatcher("/files")).authenticated()
+                        .requestMatchers(new AntPathRequestMatcher("/log/**")).authenticated()
+                        .requestMatchers(new AntPathRequestMatcher("/analyze")).authenticated()
+                        .requestMatchers(new AntPathRequestMatcher("/analyze/**")).authenticated()
+                        .anyRequest().authenticated()
 
                 )
                 .with(new JwtSecurityConfig(tokenProvider), customizer -> {})

--- a/wdam/src/main/java/com/back/wdam/user/jwt/TokenProvider.java
+++ b/wdam/src/main/java/com/back/wdam/user/jwt/TokenProvider.java
@@ -28,7 +28,7 @@ public class TokenProvider {
 
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_TYPE = "Bearer";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 1;            // 30분
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 120;            // 120분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
 
     private final Key key;

--- a/wdam/src/main/resources/application.properties
+++ b/wdam/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.application.name=wdam
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/wdam?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=0802
+spring.datasource.password=iamsoyoung@
 
 spring.jpa.properties.hibernate.show_sql=true
 
@@ -11,7 +11,7 @@ spring.jpa.properties.hibernate.format_sql=true
 
 logging.level.org.hibernate.type.descriptor.sql=trace
 
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=create
 
 #Live Reload
 spring.devtools.livereload.enabled=true


### PR DESCRIPTION
## TITLE
SecurityConfig에 api별로 인증 필요 여부 다시 정리
TokenProvider에서 토큰 만료 시간 2시간으로 연장
## 개요

## 연관된 이슈
> ex) #이슈번호, #이슈번호

## 변경사항 및 이유
토큰 만료 시간 연장(개발 시 테스트 편의용) - 배포 시에는 다시 축소
## 리뷰 요구사항(선택)
