### PR TITLE
reFix: SignUpIn SecurityConfig

### DIFF
--- a/wdam/src/main/java/com/back/wdam/user/config/SecurityConfig.java
+++ b/wdam/src/main/java/com/back/wdam/user/config/SecurityConfig.java
@@ -58,19 +58,23 @@ public class SecurityConfig {
                 .sessionManagement(httpSecuritySessionManagementConfigurer -> httpSecuritySessionManagementConfigurer
                                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)) //세션 사용 X
                 .authorizeHttpRequests((authorizeRequests) -> authorizeRequests
-                        // 인증(토큰) 없이 접속 가능한 api
+                        //인증 불필요
                         .requestMatchers(new AntPathRequestMatcher("/users/signup")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/users/login")).permitAll()
+                        //인증 필요
+                        .requestMatchers(new AntPathRequestMatcher("/users/update")).authenticated()
+                        .requestMatchers(new AntPathRequestMatcher("/users/logout")).authenticated()
+                        .requestMatchers(new AntPathRequestMatcher("/users")).authenticated()
+                        .requestMatchers(new AntPathRequestMatcher("/files")).authenticated()
+                        .requestMatchers(new AntPathRequestMatcher("/log/**")).authenticated()
+                        .requestMatchers(new AntPathRequestMatcher("/analyze")).authenticated()
+                        .requestMatchers(new AntPathRequestMatcher("/analyze/**")).authenticated()
+                        .anyRequest().authenticated()
 
-                        .requestMatchers(new AntPathRequestMatcher("/users/**")).authenticated()
-                        //.anyRequest().authenticated()  // 나머지는 인증 필요
-                        .anyRequest().permitAll()
                 )
-
                 .with(new JwtSecurityConfig(tokenProvider), customizer -> {})
                 // 프론트 연결 시 로그인, 로그아웃 페이지 연결
-                 //.formLogin((formLogin) -> formLogin
-                        //.loginProcessingUrl("users/login"));
+//                .formLogin((formLogin) -> formLogin
 //                        .loginPage("/users/login")  //로그인 페이지
 //                        .defaultSuccessUrl("/")    //로그인 성공 시 이동하는 페이지
 //                        .failureUrl("/loginfail")    // 로그인 실패 시

--- a/wdam/src/main/java/com/back/wdam/user/jwt/TokenProvider.java
+++ b/wdam/src/main/java/com/back/wdam/user/jwt/TokenProvider.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.stream.Collectors;
 
-//3강 3:00 Token Provider
 
 @Slf4j
 @Component
@@ -28,7 +27,7 @@ public class TokenProvider {
 
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_TYPE = "Bearer";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 1 * 30;            // 30분
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 120;            // 120분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
 
     private final Key key;


### PR DESCRIPTION
This reverts commit 1b94befb68e78692db899d7554bc910524c238ce.

## TITLE

## 개요
SecurityConfig에 api별로 인증 필요 여부 다시 정리
TokenProvider에서 토큰 만료 시간 2시간으로 연장
푸시 취소 후 재 머지
## 연관된 이슈
> ex) #이슈번호, #이슈번호

## 변경사항 및 이유
토큰 만료 시간 연장(개발 시 테스트 편의용) - 배포 시에는 다시 축소
## 리뷰 요구사항(선택)
